### PR TITLE
Add seed group of maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -10,6 +10,7 @@ The current Maintainers Group for the Cloud Native Compositions Project consists
 | [@matthchr](https://github.com/matthchr)                | Microsoft |                   |
 | [@nicslatts](https://github.com/nicslatts)              | Google    |                   |
 | [@rynowak](https://github.com/rynowak)                  | Microsoft |                   |
+| [@LukeMwila](https://github.com/LukeMwila)                  | AWS |                   |
 
 <!-- If-CNCF:
 This list must be kept in sync with the [CNCF Project Maintainers list](https://github.com/cncf/foundation/blob/master/project-maintainers.csv).

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,9 +1,18 @@
-The current Maintainers Group for the [TODO: Projectname] Project consists of:
+The current Maintainers Group for the Cloud Native Compositions Project consists of:
 
-| Name | Employer | Responsibilities |
-| ---- | -------- | ---------------- |
-|      |          |                  |
+| Name                                                    | Employer  | Responsibilities |
+|---------------------------------------------------------|-----------|-------------------|
+| [@a-hilaly](https://github.com/a-hilaly)                | AWS       |                   |
+| [@barney-s](https://github.com/barney-s)                | Google    |                   |
+| [@bridgetkromhout](https://github.com/bridgetkromhout)  | Microsoft |                   |
+| [@cheftako](https://github.com/cheftako)                | Google    |                   |
+| [@jlbutler](https://github.com/jlbutler)                | AWS       |                   |
+| [@matthchr](https://github.com/matthchr)                | Microsoft |                   |
+| [@nicslatts](https://github.com/nicslatts)              | Google    |                   |
+| [@rynowak](https://github.com/rynowak)                  | Microsoft |                   |
 
+<!-- If-CNCF:
 This list must be kept in sync with the [CNCF Project Maintainers list](https://github.com/cncf/foundation/blob/master/project-maintainers.csv).
+-->
 
 See [the project Governance](GOVERNANCE.md) for how maintainers are selected and replaced.


### PR DESCRIPTION
We discussed in the meeting having everyone be in the initial seed
set, and then we can split ourselves into code reviewers / project
leads etc.
